### PR TITLE
Add k8s sample

### DIFF
--- a/k8s/README.md
+++ b/k8s/README.md
@@ -1,0 +1,1 @@
+Sample k8s manifests for reference. 

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deployment
+  labels:
+    app.kubernetes.io/name: redirector
+    app.kubernetes.io/version: main
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: redirector
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: redirector
+        app.kubernetes.io/version: main
+    spec:
+      containers:
+      - name: redirector
+        image: ghcr.io/gldraphael/redirector:main
+        ports:
+        - name: http
+          containerPort: 8080
+        env:
+        - name: REDIRECTOR_RULES
+          value: /config/rules.yaml
+        volumeMounts:
+        - name: rules-config
+          mountPath: /config/rules.yaml
+          subPath: rules.yaml
+          readOnly: true
+      volumes:
+      - name: rules-config
+        configMap:
+          name: rules-config

--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: redirector
+resources:
+  - ./namespace.yaml
+  - ./deployment.yaml
+  - ./service.yaml
+
+configMapGenerator:
+  - name: rules-config
+    files:
+      - ./rules.yaml

--- a/k8s/namespace.yaml
+++ b/k8s/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: redirector

--- a/k8s/rules.yaml
+++ b/k8s/rules.yaml
@@ -1,0 +1,3 @@
+rules:
+  - slug:   github
+    target: https://github.com/gldraphael

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: service
+  labels:
+    app.kubernetes.io/name: redirector
+spec:
+  selector:
+    app.kubernetes.io/name: redirector
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: http


### PR DESCRIPTION
Adding sample ks8 files as a workaround.
I don't need a helm chart at this time. However, if we need one later, we could replace this sample with a helm chart instead.

Closes https://github.com/gldraphael/redirector/issues/6 (for now)
